### PR TITLE
Added Atlanmod contributions to Hall of Fame (halloffame and references)

### DIFF
--- a/_bibliography/references.bib
+++ b/_bibliography/references.bib
@@ -155,3 +155,19 @@ publisher={IEEE},
   publisher = {IEEE},
   note={to appear},
 }
+
+@inproceedings{cabotSaner2015,
+  title     = {{Exploring the Use of Labels to Categorize Issues in Open-Source Software Projects}},
+  author    = {Cabot, Jordi and C\'anovas Izquierdo, Javier Luis and Cosentino, Valerio and Rolandi, Bel\'en},
+  booktitle = {Proceedings of the 22nd International Conference on Software Analysis, Evolution, and Reengineering (SANER)},
+  pages     = {479--483},
+  year      = {2015}
+}
+
+@inproceedings{canovasSaner2015,
+  title     = {{GiLA: GitHub Label Analyzer}},
+  author    = {C\'anovas Izquierdo, Javier Luis and Cosentino, Valerio and Rolandi, Bel\'en and Bergel, Alexandre and Cabot, Jordi},
+  booktitle = {Proceedings of the 22nd International Conference on Software Analysis, Evolution, and Reengineering (SANER)},
+  pages     = {550--554},
+  year      = {2015}
+}

--- a/halloffame.md
+++ b/halloffame.md
@@ -13,7 +13,7 @@ Github](https://github.com/gousiosg/ghtorrent.org/blob/master/halloffame.md). Yo
 
 * If you are interested to link your publications referencing GHTorrent, you should include a Bibtex record in [this file](https://github.com/gousiosg/ghtorrent.org/blob/master/_bibliography/references.bib) on Github. You can then reference them in [this file](https://github.com/gousiosg/ghtorrent.org/blob/master/halloffame.md).
 
-#### [AtlanMod, Inria/Mines Nantes/LINA](http://www.emn.fr/z-info/atlanmod/index.php/Main_Page)
+#### [Inria/Mines Nantes/LINA/AtlanMod](http://www.emn.fr/z-info/atlanmod/index.php/Main_Page)
 * [Jordi Cabot](http://modeling-languages.com): Research on usage of issue labels in GitHub.
   1. {% reference cabotSaner2015 %}
   2. {% reference canovasSaner2015 %}

--- a/halloffame.md
+++ b/halloffame.md
@@ -13,6 +13,11 @@ Github](https://github.com/gousiosg/ghtorrent.org/blob/master/halloffame.md). Yo
 
 * If you are interested to link your publications referencing GHTorrent, you should include a Bibtex record in [this file](https://github.com/gousiosg/ghtorrent.org/blob/master/_bibliography/references.bib) on Github. You can then reference them in [this file](https://github.com/gousiosg/ghtorrent.org/blob/master/halloffame.md).
 
+#### [AtlanMod, Inria/Mines Nantes/LINA](http://www.emn.fr/z-info/atlanmod/index.php/Main_Page)
+* [Jordi Cabot](http://modeling-languages.com): Research on usage of issue labels in GitHub.
+  1. {% reference cabotSaner2015 %}
+  2. {% reference canovasSaner2015 %}
+
 #### [NUDT/Trustie](http://www.trustie.com/)
 * [Yue Yu](http://fisher.trustie.net/): Research on reviewer recommendation of pull requests. Used GHTorrent to extract our dataset.
   1. {% reference YuRR14 %}


### PR DESCRIPTION
Hi,

we used GHTorrent in GiLA, a tool to analyze the use of labels in GitHub, and published two papers about it.

I've updated the hall of fame (halloffame.md and references.md) following the indications (http://ghtorrent.org/halloffame.html)